### PR TITLE
メンバープロフィール画面のUI実装、軽微なバグの修正

### DIFF
--- a/lib/view/group/screens/group_profile_screen.dart
+++ b/lib/view/group/screens/group_profile_screen.dart
@@ -1,9 +1,8 @@
-import 'package:emo_project/view/album/screens/pictures_screen.dart';
 import 'package:emo_project/view/member/screens/members_screen.dart';
 import 'package:flutter/material.dart';
 
 class GroupProfileScreen extends StatelessWidget {
-  const GroupProfileScreen({
+  GroupProfileScreen({
     super.key,
     required this.groupName,
     required this.groupImage,
@@ -13,6 +12,16 @@ class GroupProfileScreen extends StatelessWidget {
   final String groupName;
   final String groupImage;
   final String groupDescription;
+  final List<String> groupImageUrlList = [
+    "https://cdn.pixabay.com/photo/2016/11/10/14/00/cycling-1814362_1280.jpg",
+    "https://cdn.pixabay.com/photo/2016/08/02/10/00/road-bikes-1562929_1280.jpg",
+    "https://cdn.pixabay.com/photo/2016/11/18/10/36/road-1833925_1280.jpg",
+    "https://cdn.pixabay.com/photo/2020/08/09/16/23/cyclists-5475979_1280.jpg",
+    "https://cdn.pixabay.com/photo/2016/10/06/07/56/girl-1718430_1280.jpg",
+    "https://cdn.pixabay.com/photo/2013/03/19/18/23/mountain-biking-95032_1280.jpg",
+    "https://cdn.pixabay.com/photo/2017/04/26/17/58/road-bike-2263202_1280.jpg",
+    "https://cdn.pixabay.com/photo/2018/06/11/21/50/road-bike-3469503_1280.jpg",
+  ];
 
   @override
   Widget build(BuildContext context) {
@@ -27,19 +36,44 @@ class GroupProfileScreen extends StatelessWidget {
                   MaterialPageRoute(
                     builder: (context) => const MembersScreen(
                       requestedMemberList: [
-                        {"Hiroshi" : "https://cdn.pixabay.com/photo/2016/11/23/17/25/woman-1853939_1280.jpg"}
+                        {
+                          "Hiroshi":
+                              "https://cdn.pixabay.com/photo/2016/11/23/17/25/woman-1853939_1280.jpg"
+                        }
                       ],
                       invitedMemberList: [
-                        {"Aoi" : "https://cdn.pixabay.com/photo/2016/04/24/20/56/man-1350599_1280.jpg"},
-                        {"Yuji" : "https://cdn.pixabay.com/photo/2017/11/06/13/45/cap-2923682_1280.jpg"},
+                        {
+                          "Aoi":
+                              "https://cdn.pixabay.com/photo/2016/04/24/20/56/man-1350599_1280.jpg"
+                        },
+                        {
+                          "Yuji":
+                              "https://cdn.pixabay.com/photo/2017/11/06/13/45/cap-2923682_1280.jpg"
+                        },
                       ],
                       memberList: [
-                        {"Megumi" : "https://cdn.pixabay.com/photo/2018/04/27/08/55/water-3354062_1280.jpg"},
-                        {"Taro" : "https://cdn.pixabay.com/photo/2017/12/31/15/56/portrait-3052641_1280.jpg"},
-                        {"Jiro" : "https://cdn.pixabay.com/photo/2016/05/24/18/49/suitcase-1412996_1280.jpg"},
-                        {"Saburo" : "https://cdn.pixabay.com/photo/2017/02/06/10/54/sad-2042536_1280.jpg"},
-                        {"Goro" : "https://cdn.pixabay.com/photo/2016/11/21/12/42/beard-1845166_1280.jpg"},
-                    ],),
+                        {
+                          "Megumi":
+                              "https://cdn.pixabay.com/photo/2018/04/27/08/55/water-3354062_1280.jpg"
+                        },
+                        {
+                          "Taro":
+                              "https://cdn.pixabay.com/photo/2017/12/31/15/56/portrait-3052641_1280.jpg"
+                        },
+                        {
+                          "Jiro":
+                              "https://cdn.pixabay.com/photo/2016/05/24/18/49/suitcase-1412996_1280.jpg"
+                        },
+                        {
+                          "Saburo":
+                              "https://cdn.pixabay.com/photo/2017/02/06/10/54/sad-2042536_1280.jpg"
+                        },
+                        {
+                          "Goro":
+                              "https://cdn.pixabay.com/photo/2016/11/21/12/42/beard-1845166_1280.jpg"
+                        },
+                      ],
+                    ),
                   ),
                 );
               },
@@ -80,17 +114,16 @@ class GroupProfileScreen extends StatelessWidget {
             ),
             Flexible(
               child: GridView.builder(
-                gridDelegate:
-                    const SliverGridDelegateWithFixedCrossAxisCount(
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                   crossAxisCount: 3,
                 ),
-                itemCount: albumImageUrlList.length,
+                itemCount: groupImageUrlList.length,
                 itemBuilder: (context, index) {
                   return SizedBox(
                       width: MediaQuery.of(context).size.width * 0.32,
                       height: MediaQuery.of(context).size.width * 0.32,
                       child: Image.network(
-                        albumImageUrlList[index],
+                        groupImageUrlList[index],
                         fit: BoxFit.cover,
                       ));
                 },

--- a/lib/view/home/screens/home_screen.dart
+++ b/lib/view/home/screens/home_screen.dart
@@ -28,7 +28,7 @@ class HomeScreen extends ConsumerWidget {
     const PostsScreen(),
     const AlbumsScreen(),
     const ProfileScreen(),
-    const GroupProfileScreen(
+    GroupProfileScreen(
       groupName: "グループ名",
       groupImage:
           'https://cdn.pixabay.com/photo/2018/06/11/21/50/road-bike-3469503_1280.jpg',

--- a/lib/view/member/components/member_list_item.dart
+++ b/lib/view/member/components/member_list_item.dart
@@ -1,27 +1,41 @@
+import 'package:emo_project/view/member/screens/member_profile_screen.dart';
 import 'package:flutter/material.dart';
 
 class MemberListItem extends StatelessWidget {
-  const MemberListItem({super.key, required this.memberImageUrl, required this.memberName});
+  const MemberListItem(
+      {super.key, required this.memberImageUrl, required this.memberName});
 
   final String memberImageUrl;
   final String memberName;
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8.0),
-      child: Row(
-        children: [
-          CircleAvatar(
-            radius: 25,
-            backgroundImage:
-                NetworkImage(memberImageUrl),
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => MemberProfileScreen(
+              memberImageUrl: memberImageUrl,
+              memberName: memberName,
+            ),
           ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 10.0),
-            child: Text(memberName),
-          )
-        ],
+        );
+      },
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8.0),
+        child: Row(
+          children: [
+            CircleAvatar(
+              radius: 25,
+              backgroundImage: NetworkImage(memberImageUrl),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 10.0),
+              child: Text(memberName),
+            )
+          ],
+        ),
       ),
     );
   }

--- a/lib/view/member/screens/member_profile_screen.dart
+++ b/lib/view/member/screens/member_profile_screen.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+
+class MemberProfileScreen extends StatelessWidget {
+  MemberProfileScreen(
+      {super.key, required this.memberImageUrl, required this.memberName});
+
+  final String memberImageUrl;
+  final String memberName;
+  final List<String> memberPostImageUrlList = [
+    "https://cdn.pixabay.com/photo/2016/11/10/14/00/cycling-1814362_1280.jpg",
+    "https://cdn.pixabay.com/photo/2016/08/02/10/00/road-bikes-1562929_1280.jpg",
+    "https://cdn.pixabay.com/photo/2016/11/18/10/36/road-1833925_1280.jpg",
+    "https://cdn.pixabay.com/photo/2020/08/09/16/23/cyclists-5475979_1280.jpg",
+    "https://cdn.pixabay.com/photo/2016/10/06/07/56/girl-1718430_1280.jpg",
+    "https://cdn.pixabay.com/photo/2013/03/19/18/23/mountain-biking-95032_1280.jpg",
+    "https://cdn.pixabay.com/photo/2017/04/26/17/58/road-bike-2263202_1280.jpg",
+    "https://cdn.pixabay.com/photo/2018/06/11/21/50/road-bike-3469503_1280.jpg",
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("プロフィール"),
+      ),
+      body: ListView(children: [
+        Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Row(
+            children: [
+              CircleAvatar(
+                radius: 30,
+                backgroundImage: NetworkImage(
+                  memberImageUrl,
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Text(memberName),
+              ),
+            ],
+          ),
+        ),
+        //TODO: 自己紹介文は内容を固定しているため、Member ごとのプロフィールに変更
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+              "こんにちは、佐藤と申します。私は高校時代から自転車に魅了され、大学に入ってからは「アドベンチャーシーカーズ」に参加しました。自転車を通じて日本の美しい風景を発見するのが好きです。特に長野県の山々をサイクリングするのがお気に入りです。このサークルでは、新しい場所を発見するだけでなく、自分の体力の限界に挑戦することも楽しんでいます。週末のロングライドや初心者向けの講習を一緒に楽しんでくれる新しい仲間をいつも探しています！"),
+        ),
+        const Align(
+          alignment: Alignment.centerLeft,
+          child: Padding(
+            padding: EdgeInsets.all(16.0),
+            child: Text("投稿一覧"),
+          ),
+        ),
+        //TODO: 個人投稿は内容を固定しているため、Member ごとの投稿に変更
+        GridView.builder(
+          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: 3,
+          ),
+          itemCount: memberPostImageUrlList.length,
+          itemBuilder: (context, index) {
+            return SizedBox(
+                width: MediaQuery.of(context).size.width * 0.32,
+                height: MediaQuery.of(context).size.width * 0.32,
+                child: Image.network(
+                  memberPostImageUrlList[index],
+                  fit: BoxFit.cover,
+                ));
+          },
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+        ),
+      ]),
+    );
+  }
+}


### PR DESCRIPTION
## 概要
メンバープロフィール画面のUI実装、軽微なバグの修正

## Jira
https://aleers.atlassian.net/browse/SK-49?atlOrigin=eyJpIjoiMzFiZjNiNjI2MTk2NGY0YmE4OWI3MzhiMzZiYzJlNTQiLCJwIjoiaiJ9

## スクリーンショット
<img src="https://github.com/sansan-event-fusion/spark-2023-teamK/assets/86606668/6032f30f-7543-4d75-b0fa-ec3fec441fed" width=300>

## TODO
メンバーの自己紹介文、個人投稿の内容は内容を固定しているため、バックエンドの処理実装後に書き換える

## 詳細
- メンバープロフィール画面のUI実装
- home_screen と group_profile_screen における軽微なバグの修正