### PR TITLE
pending member controller の追加

### DIFF
--- a/lib/controller/pending_member/pending_member_controller.dart
+++ b/lib/controller/pending_member/pending_member_controller.dart
@@ -8,7 +8,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'pending_member_controller.g.dart';
 
 @riverpod
-class MemberController extends _$MemberController {
+class PendingMemberController extends _$PendingMemberController {
   @override
   Future<List<PendingMember>> build({required String groupId}) async {
     final repository = ref.read(pendingMemberRepository);
@@ -42,7 +42,7 @@ class MemberController extends _$MemberController {
   }
 
   Future<String> createPendingMember(
-      {required PendingMember pendingMember, required String groupId}) async {
+      {required PendingMember pendingMember}) async {
     try {
       final docRef = await ref
           .read(pendingMemberRepository)
@@ -55,7 +55,7 @@ class MemberController extends _$MemberController {
   }
 
   Future<void> updatePendingMember(
-      {required PendingMember pendingMember, required String groupId}) async {
+      {required PendingMember pendingMember}) async {
     try {
       await ref
           .read(pendingMemberRepository)
@@ -66,7 +66,7 @@ class MemberController extends _$MemberController {
   }
 
   Future<void> deletePendingMember(
-      {required String pendingMemberId, required String groupId}) async {
+      {required String pendingMemberId}) async {
     try {
       await ref.read(pendingMemberRepository).deletePendingMember(
           pendingMemberId: pendingMemberId, groupId: groupId);

--- a/lib/controller/pending_member/pending_member_controller.dart
+++ b/lib/controller/pending_member/pending_member_controller.dart
@@ -1,40 +1,53 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:emo_project/model/pending_member/pending_member.dart';
 import 'package:emo_project/model/repository/pending_member_repository.dart';
-import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-final pendingMemberControllerProvider = StateNotifierProvider((ref) {
-  return PendingMemberController(ref);
-});
+part 'pending_member_controller.g.dart';
 
-class PendingMemberController extends StateNotifier {
-  final Ref _ref;
-  PendingMemberController(this._ref) : super(null);
+@riverpod
+class MemberController extends _$MemberController {
+  @override
+  Future<List<PendingMember>> build({required String groupId}) async {
+    final repository = ref.read(pendingMemberRepository);
+    final pendingMembers =
+        await repository.getAllPendingMemberList(groupId: groupId);
 
-  Future<List<PendingMember>> retrievePendingMembers(
-      {required String groupId}) async {
-    try {
-      final pendingMembers = await _ref
-          .watch(pendingMemberRepository)
-          .retrievePendingMembers(groupId: groupId);
-      if (mounted) {
-        state = AsyncValue.data(pendingMembers);
-      }
-      return pendingMembers;
-    } on FirebaseException catch (e) {
-      throw Exception(e.message);
-    }
+    Future(() async {
+      await Future.delayed(const Duration(milliseconds: 100));
+      streamPendingMemberList();
+    });
+
+    return pendingMembers;
+  }
+
+  /// PendingMember 監視
+  void streamPendingMemberList() {
+    ref
+        .read(pendingMemberRepository)
+        .streamPendingMemberList(groupId: groupId)
+        .then((value) {
+      StreamSubscription<QuerySnapshot> streamSub = value.listen((event) async {
+        List<PendingMember> latestPendingMemberList = await ref
+            .read(pendingMemberRepository)
+            .getLocalPendingMemberList(groupId: groupId);
+        state = AsyncData(latestPendingMemberList);
+      });
+
+      /// Snapshot キャンセル
+      ref.onDispose(() => streamSub.cancel());
+    });
   }
 
   Future<String> createPendingMember(
       {required PendingMember pendingMember, required String groupId}) async {
     try {
-      final docRef = await _ref
-          .watch(pendingMemberRepository)
+      final docRef = await ref
+          .read(pendingMemberRepository)
           .createPendingMember(pendingMember: pendingMember, groupId: groupId);
-      if (mounted) {
-        state = AsyncValue.data(docRef);
-      }
+
       return docRef;
     } on FirebaseException catch (e) {
       throw Exception(e.message);
@@ -44,8 +57,8 @@ class PendingMemberController extends StateNotifier {
   Future<void> updatePendingMember(
       {required PendingMember pendingMember, required String groupId}) async {
     try {
-      await _ref
-          .watch(pendingMemberRepository)
+      await ref
+          .read(pendingMemberRepository)
           .updatePendingMember(pendingMember: pendingMember, groupId: groupId);
     } on FirebaseException catch (e) {
       throw Exception(e.message);
@@ -55,9 +68,8 @@ class PendingMemberController extends StateNotifier {
   Future<void> deletePendingMember(
       {required String pendingMemberId, required String groupId}) async {
     try {
-      await _ref
-          .watch(pendingMemberRepository)
-          .deletePendingMember(pendingMemberId: pendingMemberId, groupId: groupId);
+      await ref.read(pendingMemberRepository).deletePendingMember(
+          pendingMemberId: pendingMemberId, groupId: groupId);
     } on FirebaseException catch (e) {
       throw Exception(e.message);
     }

--- a/lib/controller/pending_member/pending_member_controller.dart
+++ b/lib/controller/pending_member/pending_member_controller.dart
@@ -1,0 +1,65 @@
+import 'package:emo_project/model/pending_member/pending_member.dart';
+import 'package:emo_project/model/repository/pending_member_repository.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final pendingMemberControllerProvider = StateNotifierProvider((ref) {
+  return PendingMemberController(ref);
+});
+
+class PendingMemberController extends StateNotifier {
+  final Ref _ref;
+  PendingMemberController(this._ref) : super(null);
+
+  Future<List<PendingMember>> retrievePendingMembers(
+      {required String groupId}) async {
+    try {
+      final pendingMembers = await _ref
+          .watch(pendingMemberRepository)
+          .retrievePendingMembers(groupId: groupId);
+      if (mounted) {
+        state = AsyncValue.data(pendingMembers);
+      }
+      return pendingMembers;
+    } on FirebaseException catch (e) {
+      throw Exception(e.message);
+    }
+  }
+
+  Future<String> createPendingMember(
+      {required PendingMember pendingMember, required String groupId}) async {
+    try {
+      final docRef = await _ref
+          .watch(pendingMemberRepository)
+          .createPendingMember(pendingMember: pendingMember, groupId: groupId);
+      if (mounted) {
+        state = AsyncValue.data(docRef);
+      }
+      return docRef;
+    } on FirebaseException catch (e) {
+      throw Exception(e.message);
+    }
+  }
+
+  Future<void> updatePendingMember(
+      {required PendingMember pendingMember, required String groupId}) async {
+    try {
+      await _ref
+          .watch(pendingMemberRepository)
+          .updatePendingMember(pendingMember: pendingMember, groupId: groupId);
+    } on FirebaseException catch (e) {
+      throw Exception(e.message);
+    }
+  }
+
+  Future<void> deletePendingMember(
+      {required String pendingMemberId, required String groupId}) async {
+    try {
+      await _ref
+          .watch(pendingMemberRepository)
+          .deletePendingMember(pendingMemberId: pendingMemberId, groupId: groupId);
+    } on FirebaseException catch (e) {
+      throw Exception(e.message);
+    }
+  }
+}

--- a/lib/controller/pending_member/pending_member_controller.g.dart
+++ b/lib/controller/pending_member/pending_member_controller.g.dart
@@ -6,7 +6,8 @@ part of 'pending_member_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$memberControllerHash() => r'834ca44e1c2f0b1b5206929623407b2842b77e75';
+String _$pendingMemberControllerHash() =>
+    r'34eaa12a260a5bf6a447f4c81e76f8329408c86d';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -29,7 +30,7 @@ class _SystemHash {
   }
 }
 
-abstract class _$MemberController
+abstract class _$PendingMemberController
     extends BuildlessAutoDisposeAsyncNotifier<List<PendingMember>> {
   late final String groupId;
 
@@ -38,27 +39,28 @@ abstract class _$MemberController
   });
 }
 
-/// See also [MemberController].
-@ProviderFor(MemberController)
-const memberControllerProvider = MemberControllerFamily();
+/// See also [PendingMemberController].
+@ProviderFor(PendingMemberController)
+const pendingMemberControllerProvider = PendingMemberControllerFamily();
 
-/// See also [MemberController].
-class MemberControllerFamily extends Family<AsyncValue<List<PendingMember>>> {
-  /// See also [MemberController].
-  const MemberControllerFamily();
+/// See also [PendingMemberController].
+class PendingMemberControllerFamily
+    extends Family<AsyncValue<List<PendingMember>>> {
+  /// See also [PendingMemberController].
+  const PendingMemberControllerFamily();
 
-  /// See also [MemberController].
-  MemberControllerProvider call({
+  /// See also [PendingMemberController].
+  PendingMemberControllerProvider call({
     required String groupId,
   }) {
-    return MemberControllerProvider(
+    return PendingMemberControllerProvider(
       groupId: groupId,
     );
   }
 
   @override
-  MemberControllerProvider getProviderOverride(
-    covariant MemberControllerProvider provider,
+  PendingMemberControllerProvider getProviderOverride(
+    covariant PendingMemberControllerProvider provider,
   ) {
     return call(
       groupId: provider.groupId,
@@ -77,30 +79,31 @@ class MemberControllerFamily extends Family<AsyncValue<List<PendingMember>>> {
       _allTransitiveDependencies;
 
   @override
-  String? get name => r'memberControllerProvider';
+  String? get name => r'pendingMemberControllerProvider';
 }
 
-/// See also [MemberController].
-class MemberControllerProvider extends AutoDisposeAsyncNotifierProviderImpl<
-    MemberController, List<PendingMember>> {
-  /// See also [MemberController].
-  MemberControllerProvider({
+/// See also [PendingMemberController].
+class PendingMemberControllerProvider
+    extends AutoDisposeAsyncNotifierProviderImpl<PendingMemberController,
+        List<PendingMember>> {
+  /// See also [PendingMemberController].
+  PendingMemberControllerProvider({
     required String groupId,
   }) : this._internal(
-          () => MemberController()..groupId = groupId,
-          from: memberControllerProvider,
-          name: r'memberControllerProvider',
+          () => PendingMemberController()..groupId = groupId,
+          from: pendingMemberControllerProvider,
+          name: r'pendingMemberControllerProvider',
           debugGetCreateSourceHash:
               const bool.fromEnvironment('dart.vm.product')
                   ? null
-                  : _$memberControllerHash,
-          dependencies: MemberControllerFamily._dependencies,
+                  : _$pendingMemberControllerHash,
+          dependencies: PendingMemberControllerFamily._dependencies,
           allTransitiveDependencies:
-              MemberControllerFamily._allTransitiveDependencies,
+              PendingMemberControllerFamily._allTransitiveDependencies,
           groupId: groupId,
         );
 
-  MemberControllerProvider._internal(
+  PendingMemberControllerProvider._internal(
     super._createNotifier, {
     required super.name,
     required super.dependencies,
@@ -114,7 +117,7 @@ class MemberControllerProvider extends AutoDisposeAsyncNotifierProviderImpl<
 
   @override
   Future<List<PendingMember>> runNotifierBuild(
-    covariant MemberController notifier,
+    covariant PendingMemberController notifier,
   ) {
     return notifier.build(
       groupId: groupId,
@@ -122,10 +125,10 @@ class MemberControllerProvider extends AutoDisposeAsyncNotifierProviderImpl<
   }
 
   @override
-  Override overrideWith(MemberController Function() create) {
+  Override overrideWith(PendingMemberController Function() create) {
     return ProviderOverride(
       origin: this,
-      override: MemberControllerProvider._internal(
+      override: PendingMemberControllerProvider._internal(
         () => create()..groupId = groupId,
         from: from,
         name: null,
@@ -138,14 +141,14 @@ class MemberControllerProvider extends AutoDisposeAsyncNotifierProviderImpl<
   }
 
   @override
-  AutoDisposeAsyncNotifierProviderElement<MemberController, List<PendingMember>>
-      createElement() {
-    return _MemberControllerProviderElement(this);
+  AutoDisposeAsyncNotifierProviderElement<PendingMemberController,
+      List<PendingMember>> createElement() {
+    return _PendingMemberControllerProviderElement(this);
   }
 
   @override
   bool operator ==(Object other) {
-    return other is MemberControllerProvider && other.groupId == groupId;
+    return other is PendingMemberControllerProvider && other.groupId == groupId;
   }
 
   @override
@@ -157,19 +160,19 @@ class MemberControllerProvider extends AutoDisposeAsyncNotifierProviderImpl<
   }
 }
 
-mixin MemberControllerRef
+mixin PendingMemberControllerRef
     on AutoDisposeAsyncNotifierProviderRef<List<PendingMember>> {
   /// The parameter `groupId` of this provider.
   String get groupId;
 }
 
-class _MemberControllerProviderElement
-    extends AutoDisposeAsyncNotifierProviderElement<MemberController,
-        List<PendingMember>> with MemberControllerRef {
-  _MemberControllerProviderElement(super.provider);
+class _PendingMemberControllerProviderElement
+    extends AutoDisposeAsyncNotifierProviderElement<PendingMemberController,
+        List<PendingMember>> with PendingMemberControllerRef {
+  _PendingMemberControllerProviderElement(super.provider);
 
   @override
-  String get groupId => (origin as MemberControllerProvider).groupId;
+  String get groupId => (origin as PendingMemberControllerProvider).groupId;
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/controller/pending_member/pending_member_controller.g.dart
+++ b/lib/controller/pending_member/pending_member_controller.g.dart
@@ -1,0 +1,175 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pending_member_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$memberControllerHash() => r'834ca44e1c2f0b1b5206929623407b2842b77e75';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$MemberController
+    extends BuildlessAutoDisposeAsyncNotifier<List<PendingMember>> {
+  late final String groupId;
+
+  Future<List<PendingMember>> build({
+    required String groupId,
+  });
+}
+
+/// See also [MemberController].
+@ProviderFor(MemberController)
+const memberControllerProvider = MemberControllerFamily();
+
+/// See also [MemberController].
+class MemberControllerFamily extends Family<AsyncValue<List<PendingMember>>> {
+  /// See also [MemberController].
+  const MemberControllerFamily();
+
+  /// See also [MemberController].
+  MemberControllerProvider call({
+    required String groupId,
+  }) {
+    return MemberControllerProvider(
+      groupId: groupId,
+    );
+  }
+
+  @override
+  MemberControllerProvider getProviderOverride(
+    covariant MemberControllerProvider provider,
+  ) {
+    return call(
+      groupId: provider.groupId,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'memberControllerProvider';
+}
+
+/// See also [MemberController].
+class MemberControllerProvider extends AutoDisposeAsyncNotifierProviderImpl<
+    MemberController, List<PendingMember>> {
+  /// See also [MemberController].
+  MemberControllerProvider({
+    required String groupId,
+  }) : this._internal(
+          () => MemberController()..groupId = groupId,
+          from: memberControllerProvider,
+          name: r'memberControllerProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$memberControllerHash,
+          dependencies: MemberControllerFamily._dependencies,
+          allTransitiveDependencies:
+              MemberControllerFamily._allTransitiveDependencies,
+          groupId: groupId,
+        );
+
+  MemberControllerProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.groupId,
+  }) : super.internal();
+
+  final String groupId;
+
+  @override
+  Future<List<PendingMember>> runNotifierBuild(
+    covariant MemberController notifier,
+  ) {
+    return notifier.build(
+      groupId: groupId,
+    );
+  }
+
+  @override
+  Override overrideWith(MemberController Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: MemberControllerProvider._internal(
+        () => create()..groupId = groupId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        groupId: groupId,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<MemberController, List<PendingMember>>
+      createElement() {
+    return _MemberControllerProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is MemberControllerProvider && other.groupId == groupId;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, groupId.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin MemberControllerRef
+    on AutoDisposeAsyncNotifierProviderRef<List<PendingMember>> {
+  /// The parameter `groupId` of this provider.
+  String get groupId;
+}
+
+class _MemberControllerProviderElement
+    extends AutoDisposeAsyncNotifierProviderElement<MemberController,
+        List<PendingMember>> with MemberControllerRef {
+  _MemberControllerProviderElement(super.provider);
+
+  @override
+  String get groupId => (origin as MemberControllerProvider).groupId;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/view/group/screens/group_profile_screen.dart
+++ b/lib/view/group/screens/group_profile_screen.dart
@@ -35,12 +35,6 @@ class GroupProfileScreen extends StatelessWidget {
                   context,
                   MaterialPageRoute(
                     builder: (context) => const MembersScreen(
-                      requestedMemberList: [
-                        {
-                          "Hiroshi":
-                              "https://cdn.pixabay.com/photo/2016/11/23/17/25/woman-1853939_1280.jpg"
-                        }
-                      ],
                       invitedMemberList: [
                         {
                           "Aoi":

--- a/lib/view/member/screens/members_screen.dart
+++ b/lib/view/member/screens/members_screen.dart
@@ -1,19 +1,18 @@
+import 'package:emo_project/controller/pending_member/pending_member_controller.dart';
 import 'package:emo_project/view/member/components/member_list_item.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class MembersScreen extends StatelessWidget {
+class MembersScreen extends ConsumerWidget {
   const MembersScreen(
-      {super.key,
-      required this.memberList,
-      this.requestedMemberList,
-      this.invitedMemberList});
+      {super.key, required this.memberList, this.invitedMemberList});
 
-  final List<Map<String, String>>? requestedMemberList;
   final List<Map<String, String>>? invitedMemberList;
   final List<Map<String, String>> memberList;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(pendingMemberControllerProvider(groupId: "test"));
     return Scaffold(
       appBar: AppBar(
         title: const Text("メンバー一覧"),
@@ -26,16 +25,28 @@ class MembersScreen extends StatelessWidget {
               padding: EdgeInsets.symmetric(vertical: 8.0),
               child: Text("参加リクエスト"),
             ),
-            for (int i = 0;
-                requestedMemberList == null
-                    ? i < 0
-                    : i < requestedMemberList!.length;
-                i++) ...{
-              MemberListItem(
-                memberImageUrl: requestedMemberList![i].values.first,
-                memberName: requestedMemberList![i].keys.first,
-              )
-            },
+            state.when(
+              loading: () {
+                return const Center(
+                  child: CircularProgressIndicator(),
+                );
+              },
+              error: (error, stackTrace) {
+                return Text(error.toString());
+              },
+              data: (data) {
+                return Column(
+                  children: [
+                    for (int i = 0; i < data.length; i++) ...{
+                      MemberListItem(
+                        memberImageUrl: data[i].icon,
+                        memberName: data[i].name,
+                      )
+                    }
+                  ],
+                );
+              },
+            ),
             const Padding(
               padding: EdgeInsets.symmetric(vertical: 8.0),
               child: Text("招待中"),


### PR DESCRIPTION
## 概要
pending member controller の追加

## 使用例
```dart
                    onPressed: () async {
                      await ref
                          .watch(pendingMemberControllerProvider.notifier)
                          .createPendingMember(
                              pendingMember: PendingMember(
                                  pendingMemberId: "pendingMemberId",
                                  name: "name",
                                  icon: "https://icon",
                                  createdAt: DateTime.now()),
                              groupId: "groupId");
                    },
```

## 詳細
 - pending member の全取得、追加、変更、削除を controller を用いてできるように変更