### PR TITLE
album controller の追加

### DIFF
--- a/lib/controller/album/album_controller.dart
+++ b/lib/controller/album/album_controller.dart
@@ -1,0 +1,65 @@
+import 'package:emo_project/model/album/album.dart';
+import 'package:emo_project/model/repository/album_repository.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final albumControllerProvider = StateNotifierProvider((ref) {
+  return AlbumController(ref);
+});
+
+class AlbumController extends StateNotifier {
+  final Ref _ref;
+  AlbumController(this._ref) : super(null);
+
+  Future<List<Album>> retrieveAlbums(
+      {required String groupId}) async {
+    try {
+      final albums = await _ref
+          .watch(albumRepository)
+          .retrieveAlbums(groupId: groupId);
+      if (mounted) {
+        state = AsyncValue.data(albums);
+      }
+      return albums;
+    } on FirebaseException catch (e) {
+      throw Exception(e.message);
+    }
+  }
+
+  Future<String> createAlbum(
+      {required Album album, required String groupId}) async {
+    try {
+      final docRef = await _ref
+          .watch(albumRepository)
+          .createAlbum(album: album, groupId: groupId);
+      if (mounted) {
+        state = AsyncValue.data(docRef);
+      }
+      return docRef;
+    } on FirebaseException catch (e) {
+      throw Exception(e.message);
+    }
+  }
+
+  Future<void> updateAlbum(
+      {required Album album, required String groupId}) async {
+    try {
+      await _ref
+          .watch(albumRepository)
+          .updateAlbum(album: album, groupId: groupId);
+    } on FirebaseException catch (e) {
+      throw Exception(e.message);
+    }
+  }
+
+  Future<void> deleteAlbum(
+      {required String albumId, required String groupId}) async {
+    try {
+      await _ref
+          .watch(albumRepository)
+          .deleteAlbum(albumId: albumId, groupId: groupId);
+    } on FirebaseException catch (e) {
+      throw Exception(e.message);
+    }
+  }
+}

--- a/lib/controller/album/album_controller.dart
+++ b/lib/controller/album/album_controller.dart
@@ -37,7 +37,7 @@ class AlbumController extends _$AlbumController {
   }
 
   Future<String> createAlbum(
-      {required Album album, required String groupId}) async {
+      {required Album album}) async {
     try {
       final docRef = await ref
           .read(albumRepository)
@@ -50,7 +50,7 @@ class AlbumController extends _$AlbumController {
   }
 
   Future<void> updateAlbum(
-      {required Album album, required String groupId}) async {
+      {required Album album}) async {
     try {
       await ref
           .read(albumRepository)
@@ -61,7 +61,7 @@ class AlbumController extends _$AlbumController {
   }
 
   Future<void> deleteAlbum(
-      {required String albumId, required String groupId}) async {
+      {required String albumId}) async {
     try {
       await ref
           .read(albumRepository)

--- a/lib/controller/album/album_controller.g.dart
+++ b/lib/controller/album/album_controller.g.dart
@@ -1,0 +1,174 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'album_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$albumControllerHash() => r'437c1e981f760fe5c1d6c80b32fa74a7a02e9e19';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$AlbumController
+    extends BuildlessAutoDisposeAsyncNotifier<List<Album>> {
+  late final String groupId;
+
+  Future<List<Album>> build({
+    required String groupId,
+  });
+}
+
+/// See also [AlbumController].
+@ProviderFor(AlbumController)
+const albumControllerProvider = AlbumControllerFamily();
+
+/// See also [AlbumController].
+class AlbumControllerFamily extends Family<AsyncValue<List<Album>>> {
+  /// See also [AlbumController].
+  const AlbumControllerFamily();
+
+  /// See also [AlbumController].
+  AlbumControllerProvider call({
+    required String groupId,
+  }) {
+    return AlbumControllerProvider(
+      groupId: groupId,
+    );
+  }
+
+  @override
+  AlbumControllerProvider getProviderOverride(
+    covariant AlbumControllerProvider provider,
+  ) {
+    return call(
+      groupId: provider.groupId,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'albumControllerProvider';
+}
+
+/// See also [AlbumController].
+class AlbumControllerProvider
+    extends AutoDisposeAsyncNotifierProviderImpl<AlbumController, List<Album>> {
+  /// See also [AlbumController].
+  AlbumControllerProvider({
+    required String groupId,
+  }) : this._internal(
+          () => AlbumController()..groupId = groupId,
+          from: albumControllerProvider,
+          name: r'albumControllerProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$albumControllerHash,
+          dependencies: AlbumControllerFamily._dependencies,
+          allTransitiveDependencies:
+              AlbumControllerFamily._allTransitiveDependencies,
+          groupId: groupId,
+        );
+
+  AlbumControllerProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.groupId,
+  }) : super.internal();
+
+  final String groupId;
+
+  @override
+  Future<List<Album>> runNotifierBuild(
+    covariant AlbumController notifier,
+  ) {
+    return notifier.build(
+      groupId: groupId,
+    );
+  }
+
+  @override
+  Override overrideWith(AlbumController Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: AlbumControllerProvider._internal(
+        () => create()..groupId = groupId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        groupId: groupId,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<AlbumController, List<Album>>
+      createElement() {
+    return _AlbumControllerProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AlbumControllerProvider && other.groupId == groupId;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, groupId.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin AlbumControllerRef on AutoDisposeAsyncNotifierProviderRef<List<Album>> {
+  /// The parameter `groupId` of this provider.
+  String get groupId;
+}
+
+class _AlbumControllerProviderElement
+    extends AutoDisposeAsyncNotifierProviderElement<AlbumController,
+        List<Album>> with AlbumControllerRef {
+  _AlbumControllerProviderElement(super.provider);
+
+  @override
+  String get groupId => (origin as AlbumControllerProvider).groupId;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/view/album/screens/albums_screen.dart
+++ b/lib/view/album/screens/albums_screen.dart
@@ -1,30 +1,34 @@
-import 'package:emo_project/model/album/album.dart';
+import 'package:emo_project/controller/album/album_controller.dart';
 import 'package:emo_project/view/album/components/album_card.dart';
 import 'package:emo_project/view/album/screens/add_album_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class AlbumsScreen extends StatelessWidget {
+class AlbumsScreen extends ConsumerWidget {
   const AlbumsScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    List<Album> albums = [
-      Album.empty(),
-      Album.empty(),
-      Album.empty(),
-    ];
-
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(albumControllerProvider(groupId: "test"));
     return Scaffold(
       appBar: AppBar(
         title: const Text("アルバム一覧"),
         automaticallyImplyLeading: false,
       ),
-      body: ListView.separated(
-        padding: const EdgeInsets.all(16).copyWith(bottom: 80),
-        itemCount: albums.length,
-        itemBuilder: (context, index) => AlbumCard(album: albums[index]),
-        separatorBuilder: (context, index) => const SizedBox(height: 16),
-      ),
+      body: state.when(loading: () {
+        return const Center(
+          child: CircularProgressIndicator(),
+        );
+      }, error: (error, stackTrace) {
+        return Text(error.toString());
+      }, data: (data) {
+        return ListView.separated(
+          padding: const EdgeInsets.all(16).copyWith(bottom: 80),
+          itemCount: data.length,
+          itemBuilder: (context, index) => AlbumCard(album: data[index]),
+          separatorBuilder: (context, index) => const SizedBox(height: 16),
+        );
+      }),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
           Navigator.push(


### PR DESCRIPTION
## 概要
album controller の追加

## 使用例
```dart
                    onPressed: () async {
                      await ref
                          .watch(albumControllerProvider.notifier)
                          .createAlbum(
                              album: Album(
                                  albumId: "albumId",
                                  name: "albumName",
                                  description: "albumDescription",
                                  pictureCount: 10,
                                  deletedPictureCount: 5,
                                  createdAt: DateTime.now(),
                                  updatedAt: DateTime.now()),
                              groupId: "albumGroupId");
                    },
```

## 詳細
 - album の全取得、追加、変更、削除を controller を用いてできるように変更