### PR TITLE
[BE]: アルバム画像追加(addAlbumPictures)の実装

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,6 +3,7 @@ import {
   deleteMember as deleteMemberFn,
   acceptInvitation as acceptInvitationFn,
   approveRequest as approveRequestFn,
+  addAlbumPictures as addAlbumPicturesFn,
 } from "./modules";
 import { functions } from "./lib/firebase";
 
@@ -21,3 +22,7 @@ export const acceptInvitation = functions
 export const approveRequest = functions
   .region("us-central1")
   .https.onCall(approveRequestFn);
+
+export const addAlbumPictures = functions
+  .region("us-central1")
+  .https.onCall(addAlbumPicturesFn);

--- a/functions/src/model/groups/albums/album_pictures/index.ts
+++ b/functions/src/model/groups/albums/album_pictures/index.ts
@@ -1,0 +1,8 @@
+import { FieldValue } from "firebase-admin/firestore";
+
+export type AlbumPicture = {
+  albumPictureId: string;
+  memberId: string;
+  imageUrl: string;
+  createdAt: Date | FieldValue;
+};

--- a/functions/src/model/groups/albums/index.ts
+++ b/functions/src/model/groups/albums/index.ts
@@ -1,0 +1,11 @@
+import { FieldValue } from "firebase-admin/firestore";
+
+export type Album = {
+  albumId: string;
+  name: string;
+  description: string;
+  pictureCount: number;
+  deletedPictureCount: number;
+  createdAt: Date | FieldValue;
+  updatedAt: Date | FieldValue;
+};

--- a/functions/src/modules/addAlbumPictures.ts
+++ b/functions/src/modules/addAlbumPictures.ts
@@ -1,0 +1,101 @@
+import { firestore } from "../lib/firebase";
+import { FieldValue } from "firebase-admin/firestore";
+
+import { HttpHandler } from "../types";
+import { logger } from "firebase-functions";
+import { AlbumPicture } from "../model/groups/albums/album_pictures";
+
+type RequestData = {
+  groupId: string;
+  albumId: string;
+  memberId: string;
+  pictureUrls: string[];
+};
+
+type ResponseData = {
+  success: boolean;
+  message?: string;
+};
+
+// アルバム画像追加
+// ユーザーがアルバムに画像を追加するとき
+
+// [内容]
+// DB
+// [POST]: アルバム画像追加(groups/albums/album_pictures)
+// [PATCH]: アルバムの画像枚数更新(groups/albums)
+
+const db = firestore();
+
+export const addAlbumPictures: HttpHandler<RequestData, ResponseData> = async (
+  data,
+  _
+) => {
+  try {
+    // 画像URLが空の場合はエラー
+    if (data.pictureUrls.length === 0) {
+      throw new Error("pictureUrls is empty");
+    }
+
+    // ユーザー、グループ、アルバムの存在確認
+    const groupDocRef = db.collection("groups").doc(data.groupId);
+    const memberDocRef = groupDocRef.collection("members").doc(data.memberId);
+    const albumDocRef = groupDocRef.collection("albums").doc(data.albumId);
+
+    const [groupDoc, memberDoc, albumDoc] = await Promise.all([
+      groupDocRef.get(),
+      memberDocRef.get(),
+      albumDocRef.get(),
+    ]);
+
+    if (!groupDoc.exists) {
+      throw new Error("group not found");
+    }
+    if (!memberDoc.exists) {
+      throw new Error("member not found");
+    }
+    if (!albumDoc.exists) {
+      throw new Error("album not found");
+    }
+
+    const batch = db.batch();
+
+    // [POST]: アルバム画像追加(groups/albums/album_pictures)
+    const albumPictureDocRef = albumDocRef.collection("album_pictures");
+    data.pictureUrls.forEach((pictureUrl) => {
+      const pictureDocRef = albumPictureDocRef.doc();
+      const albumPictureBody: AlbumPicture = {
+        albumPictureId: pictureDocRef.id,
+        memberId: data.memberId,
+        imageUrl: pictureUrl,
+        createdAt: FieldValue.serverTimestamp(),
+      };
+      batch.set(pictureDocRef, albumPictureBody);
+    });
+
+    // [PATCH]: アルバムの画像枚数更新(groups/albums)
+    const updateAlbumBody = {
+      pictureCount: FieldValue.increment(data.pictureUrls.length),
+      updatedAt: FieldValue.serverTimestamp(),
+    };
+    batch.update(albumDocRef, updateAlbumBody);
+
+    await batch.commit();
+
+    return {
+      success: true,
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      logger.error(error.message);
+      return {
+        success: false,
+        message: error.message,
+      };
+    }
+    return {
+      success: false,
+      message: "unknown error",
+    };
+  }
+};

--- a/functions/src/modules/index.ts
+++ b/functions/src/modules/index.ts
@@ -2,3 +2,4 @@ export { createGroup } from "./createGroup";
 export { deleteMember } from "./deleteMember";
 export { acceptInvitation } from "./acceptInvitation";
 export { approveRequest } from "./approveRequest";
+export { addAlbumPictures } from "./addAlbumPictures";


### PR DESCRIPTION
#  アルバム画像追加（`addAlbumPictures`）
## 説明
ユーザーがアルバムに画像を追加するとき
## 内容
  - 【POST】アルバム画像追加(groups/albums/album_pictures)
  - 【PATCH】: アルバムの画像枚数更新(groups/albums)
## RequestData
```
{
  groupId: string;
  albumId: string;
  memberId: string;
  pictureUrls: string[];
}
```